### PR TITLE
OrthoVec: Implement more `Vec<>` methods

### DIFF
--- a/ortho_vec_derive/README.md
+++ b/ortho_vec_derive/README.md
@@ -73,6 +73,8 @@ The `OrthoVec` derive macro tries to solve these issues.
 ### ortho-`Vec`
 
 All of these are the same as the `Vec` methods
++ `new()`
++ `with_capacity()`
 + `iter()`
 + `iter_mut()`
 + `into_iter()`
@@ -82,6 +84,9 @@ All of these are the same as the `Vec` methods
 + `clear()`
 + `reverse()`
 + `shrink_to_fit()`
++ `insert()`
++ `remove()`
++ `swap_remove()`
 
 The only caveat is that, when iterating with `iter_mut()`, you get a `struct` that contains a `&mut` to each inner `Vec`.&nbsp;
 To use it you have to dereference it by adding a `*` prefix.
@@ -140,7 +145,8 @@ fn main () {
 
 Results may vary between use-cases and platforms.&nbsp;
 Running a small benchmark (which is in the crate's repo) we can see a maximum of around 6X speedup, this is at 1M/10M but at sizes like 10K/100K we can also see speedup of around 2-3X.&nbsp;
-It is recommended that you just try to bench the 2 versions of the code against each other, this way you can be sure this is working in your case.
+It is recommended that you just try to bench the 2 versions of the code against each other, this way you can be sure this is working in your case.&nbsp;
+It is expected to work best when most use-cases involve iterating over elements and using a few of their fields at a time.
 
 ## Notes
 

--- a/ortho_vec_derive/src/lib.rs
+++ b/ortho_vec_derive/src/lib.rs
@@ -27,47 +27,97 @@ mod tests {
         c: T,
     }
 
+    struct TestContext<'a> {
+        v_ws: OrthoVecWeirdStruct<'a, &'a str>,
+    }
+
+    impl<'a> TestContext<'a> {
+        fn setup() -> Self {
+            Self {
+                v_ws: vec![
+                    WeirdStruct {
+                        a: 3,
+                        b: &4.2,
+                        c: "wow",
+                    },
+                    WeirdStruct {
+                        a: 6,
+                        b: &24.2,
+                        c: "hello",
+                    },
+                ]
+                .into_ortho(),
+            }
+        }
+    }
+
     #[test]
     fn test_use_weird_struct() {
-        let mut v_ws = vec![
-            WeirdStruct {
-                a: 3,
-                b: &4.2,
-                c: "wow",
-            },
-            WeirdStruct {
-                a: 6,
-                b: &24.2,
-                c: "hello",
-            },
-        ]
-        .into_ortho();
-        assert_eq!(v_ws.len(), 2);
+        let mut ctx = TestContext::setup();
+        assert_eq!(ctx.v_ws.len(), 2);
 
-        let last_element = v_ws.pop().expect("There must be a last element");
-        assert_eq!(v_ws.len(), 1);
+        let last_element = ctx.v_ws.pop().expect("There must be a last element");
+        assert_eq!(ctx.v_ws.len(), 1);
 
         assert_eq!(last_element.a, 6);
         assert!((*last_element.b - 24.2).abs() < f32::EPSILON);
         assert_eq!(last_element.c, "hello");
 
-        v_ws.push(WeirdStruct {
+        ctx.v_ws.push(WeirdStruct {
             a: 7,
             b: &8.123,
             c: "push",
         });
-        assert_eq!(v_ws.len(), 2);
+        assert_eq!(ctx.v_ws.len(), 2);
 
-        v_ws.reverse();
+        ctx.v_ws.reverse();
 
-        for x in v_ws.iter() {
+        for x in ctx.v_ws.iter() {
             println!("a is {:?}", x.a);
             println!("b is {:?}", x.b);
             println!("c is {:?}", x.c);
         }
 
-        assert_eq!(v_ws.len(), 2);
-        v_ws.clear();
-        assert_eq!(v_ws.len(), 0);
+        assert_eq!(ctx.v_ws.len(), 2);
+        ctx.v_ws.clear();
+        assert_eq!(ctx.v_ws.len(), 0);
+    }
+
+    #[test]
+    fn test_insert_remove() {
+        let mut ctx = TestContext::setup();
+
+        ctx.v_ws.insert(
+            1,
+            WeirdStruct {
+                a: 7,
+                b: &3.0,
+                c: "in the middle",
+            },
+        );
+        assert_eq!(ctx.v_ws.len(), 3);
+        assert_eq!(ctx.v_ws.pop().unwrap().a, 6);
+        assert_eq!(ctx.v_ws.len(), 2);
+        assert_eq!(ctx.v_ws.remove(1).a, 7);
+        assert_eq!(ctx.v_ws.len(), 1);
+        assert_eq!(ctx.v_ws.remove(0).a, 3);
+        assert_eq!(ctx.v_ws.len(), 0);
+    }
+
+    #[test]
+    fn test_swap_remove() {
+        let mut ctx = TestContext::setup();
+
+        ctx.v_ws.push(WeirdStruct {
+            a: 7,
+            b: &3.0,
+            c: "Going to the start",
+        });
+
+        assert_eq!(ctx.v_ws.len(), 3);
+        ctx.v_ws.swap_remove(0);
+        assert_eq!(ctx.v_ws.len(), 2);
+
+        assert_eq!(ctx.v_ws.remove(0).c, "Going to the start");
     }
 }


### PR DESCRIPTION
Implements:
+ `insert()`
+ `remove()`
+ `swap_remove()`
+ `new()`
+ `with_capacity()`